### PR TITLE
Add Bolt configuration files

### DIFF
--- a/bolt.yaml
+++ b/bolt.yaml
@@ -1,0 +1,2 @@
+---
+{} # this is here so linters don't get mad about an empty file

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,2 @@
 ---
+{} # this is here so linters don't get mad about an empty file

--- a/project.yaml
+++ b/project.yaml
@@ -1,0 +1,4 @@
+---
+name: 'piweatherrock'
+tasks:
+  - 'piweatherrock::pisetup'


### PR DESCRIPTION
Adding `bolt.yaml` and `project.yaml` makes it so that Bolt knows that it should both include the `piweatherrock::pisetup` task and hide other tasks when run from within this project.