### PR TITLE
Whitelist more tasks in project.yaml

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -2,3 +2,6 @@
 name: 'piweatherrock'
 tasks:
   - 'piweatherrock::pisetup'
+  - 'reboot'
+  - 'reboot::last_boot_time'
+  - 'service'


### PR DESCRIPTION
This commit whitelists additional tasks used during the setup of
PiWeatherRock