### PR TITLE
Create a migration task and update config location

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -12,6 +12,7 @@
 
 **Tasks**
 
+* [`migrate_from_git`](#migrate_from_git): Migrate from the git version of PiWeatherRock
 * [`pisetup`](#pisetup): Do the initial setup of PiWeatherRock on a Raspberry Pi
 
 ## Classes
@@ -55,7 +56,7 @@ Data type: `Stdlib::Unixpath`
 
 The path to the config file for PiWeatherRock
 
-Default value: '/home/pi/PiWeatherRock/config.json'
+Default value: '/home/pi/piweatherrock-config.json'
 
 ##### `sample_config_file`
 
@@ -71,7 +72,7 @@ Data type: `String[1]`
 
 The version of piweatherrock to install from PyPI
 
-Default value: '2.0.0.dev8'
+Default value: '2.0.0rc1'
 
 ##### `user`
 
@@ -102,6 +103,12 @@ Handles the installation steps for PiWeatherRock
 Manages services associated with PiWeatherRock
 
 ## Tasks
+
+### migrate_from_git
+
+Migrate from the git version of PiWeatherRock
+
+**Supports noop?** false
 
 ### pisetup
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,9 +31,9 @@
 #
 class piweatherrock (
   Boolean $enable_awesome_desktop = false,
-  Stdlib::Unixpath $config_file = '/home/pi/PiWeatherRock/config.json',
+  Stdlib::Unixpath $config_file = '/home/pi/piweatherrock-config.json',
   Stdlib::Unixpath $sample_config_file = '/usr/local/lib/python3.7/dist-packages/piweatherrock/config.json-sample',
-  String[1] $piweatherrock_version = '2.0.0.dev8',
+  String[1] $piweatherrock_version = '2.0.0rc1',
   String[1] $user = 'pi',
   String[1] $group = 'pi',
 ) {

--- a/project.yaml
+++ b/project.yaml
@@ -1,6 +1,7 @@
 ---
 name: 'piweatherrock'
 tasks:
+  - 'piweatherrock::migrate_from_git'
   - 'piweatherrock::pisetup'
   - 'reboot'
   - 'reboot::last_boot_time'

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -40,17 +40,17 @@ describe 'piweatherrock::config' do
         it {
           is_expected.to contain_exec('import config')
             .with_user('pi')
-            .with_command('pwr-config-upgrade -c /home/pi/PiWeatherRock/config.json -s /usr/local/lib/python3.7/dist-packages/piweatherrock/config.json-sample')
+            .with_command('pwr-config-upgrade -c /home/pi/piweatherrock-config.json -s /usr/local/lib/python3.7/dist-packages/piweatherrock/config.json-sample')
         }
 
         it {
           is_expected.to contain_systemd__unit_file('PiWeatherRock.service')
-            .with_content(%r{/home/pi/PiWeatherRock/config.json})
+            .with_content(%r{/home/pi/piweatherrock-config.json})
         }
 
         it {
           is_expected.to contain_systemd__unit_file('PiWeatherRockConfig.service')
-            .with_content(%r{/home/pi/PiWeatherRock/config.json})
+            .with_content(%r{/home/pi/piweatherrock-config.json})
         }
       end
     end

--- a/tasks/migrate_from_git.json
+++ b/tasks/migrate_from_git.json
@@ -1,0 +1,7 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Migrate from the git version of PiWeatherRock",
+  "parameters": {
+  }
+}

--- a/tasks/migrate_from_git.sh
+++ b/tasks/migrate_from_git.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Puppet Task Name: migrate_from_git
+
+set -e
+
+if [[ $(id -u) -ne 0 ]]; then
+  echo "{ \"_error\": {
+    \"msg\": \"Please add '--run-as root' to your bolt command\",
+    \"kind\": \"puppetlabs.tasks/task-error\",
+    \"details\": { \"exitcode\": 1 }
+  }"
+  exit 1
+fi
+
+# make sure the old version of epel isn't installed
+rm -rf /etc/puppet/code/modules/epel
+
+# Install this puppet module on the Pi
+puppet module install genebean-piweatherrock
+
+# Migrate the old config file and set permissions on it
+if [[ -f '/home/pi/PiWeatherRock/config.json' ]]; then
+  # this is the most recent version of the config that was used with the non-PyPI version of PiWeatherRock
+  puppet resource file '/home/pi/piweatherrock-config.json' ensure='file' owner='pi' group='pi' mode='0644' source='/home/pi/PiWeatherRock/config.json'
+elif [[ -f '/home/pi/PiWeatherRock/config.py' ]]; then
+  # this is the original version of the config that was used with the non-PyPI version of PiWeatherRock
+  puppet resource file '/home/pi/config.py' ensure='file' owner='pi' group='pi' mode='0644' source='/home/pi/PiWeatherRock/config.py'
+else
+  echo "{ \"_error\": {
+    \"msg\": \"Unable to find an old config file at either '/home/pi/PiWeatherRock/config.json' or '/home/pi/PiWeatherRock/config.py'\",
+    \"kind\": \"puppetlabs.tasks/task-error\",
+    \"details\": { \"exitcode\": 2 }
+  }"
+  exit 2
+fi
+
+# Setup PiWeatherRock itself
+puppet apply -e 'include piweatherrock'


### PR DESCRIPTION
This PR includes a new task that will migrate an existing config file for PiWeatherRock from the previously recommended install location to the new one and ensure that it has the proper permissions on it.

This commit also changes the default location of the config file to directly in the user's home directory. The end result of this is that after applying this module there will be a new-style configuration located at `/home/pi/piweatherrock-config.json`