### PR TITLE
Ignore the .rerun.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+.rerun.json

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,7 @@
 ---
+.gitignore:
+  paths:
+    - '.rerun.json'
 .gitlab-ci.yml:
   delete: true
 appveyor.yml:


### PR DESCRIPTION
Bolt create a .rerun.json any time a run fails on a target. This tells
git to disregard that file.