### PR TITLE
Default to latest version of piweatherrock

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -72,7 +72,7 @@ Data type: `String[1]`
 
 The version of piweatherrock to install from PyPI
 
-Default value: '2.1.0'
+Default value: 'latest'
 
 ##### `user`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@ class piweatherrock (
   Boolean $enable_awesome_desktop = false,
   Stdlib::Unixpath $config_file = '/home/pi/piweatherrock-config.json',
   Stdlib::Unixpath $sample_config_file = '/usr/local/lib/python3.7/dist-packages/piweatherrock/config.json-sample',
-  String[1] $piweatherrock_version = '2.1.0',
+  String[1] $piweatherrock_version = 'latest',
   String[1] $user = 'pi',
   String[1] $group = 'pi',
 ) {


### PR DESCRIPTION
Previously a version was hard coded. This was intened to support working with thins before a stable version was released.